### PR TITLE
update schemas to support geneSearch generator

### DIFF
--- a/python/ga4gh/schemas/ga4gh/variant_service_pb2.py
+++ b/python/ga4gh/schemas/ga4gh/variant_service_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='ga4gh/schemas/ga4gh/variant_service.proto',
   package='ga4gh',
   syntax='proto3',
-  serialized_pb=_b('\n)ga4gh/schemas/ga4gh/variant_service.proto\x12\x05ga4gh\x1a\"ga4gh/schemas/ga4gh/variants.proto\x1a*ga4gh/schemas/google/api/annotations.proto\"U\n\x18SearchVariantSetsRequest\x12\x12\n\ndataset_id\x18\x01 \x01(\t\x12\x11\n\tpage_size\x18\x02 \x01(\x05\x12\x12\n\npage_token\x18\x03 \x01(\t\"]\n\x19SearchVariantSetsResponse\x12\'\n\x0cvariant_sets\x18\x01 \x03(\x0b\x32\x11.ga4gh.VariantSet\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\".\n\x14GetVariantSetRequest\x12\x16\n\x0evariant_set_id\x18\x01 \x01(\t\"\xa0\x01\n\x15SearchVariantsRequest\x12\x16\n\x0evariant_set_id\x18\x01 \x01(\t\x12\x14\n\x0c\x63\x61ll_set_ids\x18\x02 \x03(\t\x12\x16\n\x0ereference_name\x18\x03 \x01(\t\x12\r\n\x05start\x18\x04 \x01(\x03\x12\x0b\n\x03\x65nd\x18\x05 \x01(\x03\x12\x11\n\tpage_size\x18\x06 \x01(\x05\x12\x12\n\npage_token\x18\x07 \x01(\t\"S\n\x16SearchVariantsResponse\x12 \n\x08variants\x18\x01 \x03(\x0b\x32\x0e.ga4gh.Variant\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"\'\n\x11GetVariantRequest\x12\x12\n\nvariant_id\x18\x01 \x01(\t\"z\n\x15SearchCallSetsRequest\x12\x16\n\x0evariant_set_id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x14\n\x0c\x62iosample_id\x18\x03 \x01(\t\x12\x11\n\tpage_size\x18\x04 \x01(\x05\x12\x12\n\npage_token\x18\x05 \x01(\t\"T\n\x16SearchCallSetsResponse\x12!\n\tcall_sets\x18\x01 \x03(\x0b\x32\x0e.ga4gh.CallSet\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"(\n\x11GetCallSetRequest\x12\x13\n\x0b\x63\x61ll_set_id\x18\x01 \x01(\t2\xb6\x05\n\x0eVariantService\x12\x80\x01\n\x11SearchVariantSets\x12\x1f.ga4gh.SearchVariantSetsRequest\x1a .ga4gh.SearchVariantSetsResponse\"(\x82\xd3\xe4\x93\x02\"\"\x1d/v0.6.0a10/variantsets/search:\x01*\x12p\n\rGetVariantSet\x12\x1b.ga4gh.GetVariantSetRequest\x1a\x11.ga4gh.VariantSet\"/\x82\xd3\xe4\x93\x02)\x12\'/v0.6.0a10/variantsets/{variant_set_id}\x12t\n\x0eSearchVariants\x12\x1c.ga4gh.SearchVariantsRequest\x1a\x1d.ga4gh.SearchVariantsResponse\"%\x82\xd3\xe4\x93\x02\x1f\"\x1a/v0.6.0a10/variants/search:\x01*\x12`\n\nGetVariant\x12\x18.ga4gh.GetVariantRequest\x1a\x0e.ga4gh.Variant\"(\x82\xd3\xe4\x93\x02\"\" /v0.6.0a10/variants/{variant_id}\x12t\n\x0eSearchCallSets\x12\x1c.ga4gh.SearchCallSetsRequest\x1a\x1d.ga4gh.SearchCallSetsResponse\"%\x82\xd3\xe4\x93\x02\x1f\"\x1a/v0.6.0a10/callsets/search:\x01*\x12\x61\n\nGetCallSet\x12\x18.ga4gh.GetCallSetRequest\x1a\x0e.ga4gh.CallSet\")\x82\xd3\xe4\x93\x02#\x12!/v0.6.0a10/callsets/{call_set_id}b\x06proto3')
+  serialized_pb=_b('\n)ga4gh/schemas/ga4gh/variant_service.proto\x12\x05ga4gh\x1a\"ga4gh/schemas/ga4gh/variants.proto\x1a*ga4gh/schemas/google/api/annotations.proto\"U\n\x18SearchVariantSetsRequest\x12\x12\n\ndataset_id\x18\x01 \x01(\t\x12\x11\n\tpage_size\x18\x02 \x01(\x05\x12\x12\n\npage_token\x18\x03 \x01(\t\"]\n\x19SearchVariantSetsResponse\x12\'\n\x0cvariant_sets\x18\x01 \x03(\x0b\x32\x11.ga4gh.VariantSet\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\".\n\x14GetVariantSetRequest\x12\x16\n\x0evariant_set_id\x18\x01 \x01(\t\"\xa0\x01\n\x15SearchVariantsRequest\x12\x16\n\x0evariant_set_id\x18\x01 \x01(\t\x12\x14\n\x0c\x63\x61ll_set_ids\x18\x02 \x03(\t\x12\x16\n\x0ereference_name\x18\x03 \x01(\t\x12\r\n\x05start\x18\x04 \x01(\x03\x12\x0b\n\x03\x65nd\x18\x05 \x01(\x03\x12\x11\n\tpage_size\x18\x06 \x01(\x05\x12\x12\n\npage_token\x18\x07 \x01(\t\"S\n\x16SearchVariantsResponse\x12 \n\x08variants\x18\x01 \x03(\x0b\x32\x0e.ga4gh.Variant\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"\'\n\x11GetVariantRequest\x12\x12\n\nvariant_id\x18\x01 \x01(\t\"z\n\x15SearchCallSetsRequest\x12\x16\n\x0evariant_set_id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x14\n\x0c\x62iosample_id\x18\x03 \x01(\t\x12\x11\n\tpage_size\x18\x04 \x01(\x05\x12\x12\n\npage_token\x18\x05 \x01(\t\"T\n\x16SearchCallSetsResponse\x12!\n\tcall_sets\x18\x01 \x03(\x0b\x32\x0e.ga4gh.CallSet\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"(\n\x11GetCallSetRequest\x12\x13\n\x0b\x63\x61ll_set_id\x18\x01 \x01(\t\"j\n\x1fSearchVariantsByGeneNameRequest\x12\x12\n\ndataset_id\x18\x01 \x01(\t\x12\x0c\n\x04gene\x18\x02 \x01(\t\x12\x11\n\tpage_size\x18\x03 \x01(\x05\x12\x12\n\npage_token\x18\x04 \x01(\t\"]\n SearchVariantsByGeneNameResponse\x12 \n\x08variants\x18\x01 \x03(\x0b\x32\x0e.ga4gh.Variant\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t2\xd0\x06\n\x0eVariantService\x12\x80\x01\n\x11SearchVariantSets\x12\x1f.ga4gh.SearchVariantSetsRequest\x1a .ga4gh.SearchVariantSetsResponse\"(\x82\xd3\xe4\x93\x02\"\"\x1d/v0.6.0a10/variantsets/search:\x01*\x12\x97\x01\n\x18SearchVariantsByGeneName\x12&.ga4gh.SearchVariantsByGeneNameRequest\x1a\'.ga4gh.SearchVariantsByGeneNameResponse\"*\x82\xd3\xe4\x93\x02$\"\x1f/v0.6.0a10/variantsbygenesearch:\x01*\x12p\n\rGetVariantSet\x12\x1b.ga4gh.GetVariantSetRequest\x1a\x11.ga4gh.VariantSet\"/\x82\xd3\xe4\x93\x02)\x12\'/v0.6.0a10/variantsets/{variant_set_id}\x12t\n\x0eSearchVariants\x12\x1c.ga4gh.SearchVariantsRequest\x1a\x1d.ga4gh.SearchVariantsResponse\"%\x82\xd3\xe4\x93\x02\x1f\"\x1a/v0.6.0a10/variants/search:\x01*\x12`\n\nGetVariant\x12\x18.ga4gh.GetVariantRequest\x1a\x0e.ga4gh.Variant\"(\x82\xd3\xe4\x93\x02\"\" /v0.6.0a10/variants/{variant_id}\x12t\n\x0eSearchCallSets\x12\x1c.ga4gh.SearchCallSetsRequest\x1a\x1d.ga4gh.SearchCallSetsResponse\"%\x82\xd3\xe4\x93\x02\x1f\"\x1a/v0.6.0a10/callsets/search:\x01*\x12\x61\n\nGetCallSet\x12\x18.ga4gh.GetCallSetRequest\x1a\x0e.ga4gh.CallSet\")\x82\xd3\xe4\x93\x02#\x12!/v0.6.0a10/callsets/{call_set_id}b\x06proto3')
   ,
   dependencies=[ga4gh_dot_schemas_dot_ga4gh_dot_variants__pb2.DESCRIPTOR,ga4gh_dot_schemas_dot_google_dot_api_dot_annotations__pb2.DESCRIPTOR,])
 
@@ -411,9 +411,100 @@ _GETCALLSETREQUEST = _descriptor.Descriptor(
   serialized_end=901,
 )
 
+
+_SEARCHVARIANTSBYGENENAMEREQUEST = _descriptor.Descriptor(
+  name='SearchVariantsByGeneNameRequest',
+  full_name='ga4gh.SearchVariantsByGeneNameRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='dataset_id', full_name='ga4gh.SearchVariantsByGeneNameRequest.dataset_id', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='gene', full_name='ga4gh.SearchVariantsByGeneNameRequest.gene', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='page_size', full_name='ga4gh.SearchVariantsByGeneNameRequest.page_size', index=2,
+      number=3, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='page_token', full_name='ga4gh.SearchVariantsByGeneNameRequest.page_token', index=3,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=903,
+  serialized_end=1009,
+)
+
+
+_SEARCHVARIANTSBYGENENAMERESPONSE = _descriptor.Descriptor(
+  name='SearchVariantsByGeneNameResponse',
+  full_name='ga4gh.SearchVariantsByGeneNameResponse',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='variants', full_name='ga4gh.SearchVariantsByGeneNameResponse.variants', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='next_page_token', full_name='ga4gh.SearchVariantsByGeneNameResponse.next_page_token', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1011,
+  serialized_end=1104,
+)
+
 _SEARCHVARIANTSETSRESPONSE.fields_by_name['variant_sets'].message_type = ga4gh_dot_schemas_dot_ga4gh_dot_variants__pb2._VARIANTSET
 _SEARCHVARIANTSRESPONSE.fields_by_name['variants'].message_type = ga4gh_dot_schemas_dot_ga4gh_dot_variants__pb2._VARIANT
 _SEARCHCALLSETSRESPONSE.fields_by_name['call_sets'].message_type = ga4gh_dot_schemas_dot_ga4gh_dot_variants__pb2._CALLSET
+_SEARCHVARIANTSBYGENENAMERESPONSE.fields_by_name['variants'].message_type = ga4gh_dot_schemas_dot_ga4gh_dot_variants__pb2._VARIANT
 DESCRIPTOR.message_types_by_name['SearchVariantSetsRequest'] = _SEARCHVARIANTSETSREQUEST
 DESCRIPTOR.message_types_by_name['SearchVariantSetsResponse'] = _SEARCHVARIANTSETSRESPONSE
 DESCRIPTOR.message_types_by_name['GetVariantSetRequest'] = _GETVARIANTSETREQUEST
@@ -423,6 +514,8 @@ DESCRIPTOR.message_types_by_name['GetVariantRequest'] = _GETVARIANTREQUEST
 DESCRIPTOR.message_types_by_name['SearchCallSetsRequest'] = _SEARCHCALLSETSREQUEST
 DESCRIPTOR.message_types_by_name['SearchCallSetsResponse'] = _SEARCHCALLSETSRESPONSE
 DESCRIPTOR.message_types_by_name['GetCallSetRequest'] = _GETCALLSETREQUEST
+DESCRIPTOR.message_types_by_name['SearchVariantsByGeneNameRequest'] = _SEARCHVARIANTSBYGENENAMEREQUEST
+DESCRIPTOR.message_types_by_name['SearchVariantsByGeneNameResponse'] = _SEARCHVARIANTSBYGENENAMERESPONSE
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 SearchVariantSetsRequest = _reflection.GeneratedProtocolMessageType('SearchVariantSetsRequest', (_message.Message,), dict(
@@ -488,74 +581,19 @@ GetCallSetRequest = _reflection.GeneratedProtocolMessageType('GetCallSetRequest'
   ))
 _sym_db.RegisterMessage(GetCallSetRequest)
 
+SearchVariantsByGeneNameRequest = _reflection.GeneratedProtocolMessageType('SearchVariantsByGeneNameRequest', (_message.Message,), dict(
+  DESCRIPTOR = _SEARCHVARIANTSBYGENENAMEREQUEST,
+  __module__ = 'ga4gh.schemas.ga4gh.variant_service_pb2'
+  # @@protoc_insertion_point(class_scope:ga4gh.SearchVariantsByGeneNameRequest)
+  ))
+_sym_db.RegisterMessage(SearchVariantsByGeneNameRequest)
 
+SearchVariantsByGeneNameResponse = _reflection.GeneratedProtocolMessageType('SearchVariantsByGeneNameResponse', (_message.Message,), dict(
+  DESCRIPTOR = _SEARCHVARIANTSBYGENENAMERESPONSE,
+  __module__ = 'ga4gh.schemas.ga4gh.variant_service_pb2'
+  # @@protoc_insertion_point(class_scope:ga4gh.SearchVariantsByGeneNameResponse)
+  ))
+_sym_db.RegisterMessage(SearchVariantsByGeneNameResponse)
 
-_VARIANTSERVICE = _descriptor.ServiceDescriptor(
-  name='VariantService',
-  full_name='ga4gh.VariantService',
-  file=DESCRIPTOR,
-  index=0,
-  options=None,
-  serialized_start=904,
-  serialized_end=1598,
-  methods=[
-  _descriptor.MethodDescriptor(
-    name='SearchVariantSets',
-    full_name='ga4gh.VariantService.SearchVariantSets',
-    index=0,
-    containing_service=None,
-    input_type=_SEARCHVARIANTSETSREQUEST,
-    output_type=_SEARCHVARIANTSETSRESPONSE,
-    options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002\"\"\035/v0.6.0a10/variantsets/search:\001*')),
-  ),
-  _descriptor.MethodDescriptor(
-    name='GetVariantSet',
-    full_name='ga4gh.VariantService.GetVariantSet',
-    index=1,
-    containing_service=None,
-    input_type=_GETVARIANTSETREQUEST,
-    output_type=ga4gh_dot_schemas_dot_ga4gh_dot_variants__pb2._VARIANTSET,
-    options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002)\022\'/v0.6.0a10/variantsets/{variant_set_id}')),
-  ),
-  _descriptor.MethodDescriptor(
-    name='SearchVariants',
-    full_name='ga4gh.VariantService.SearchVariants',
-    index=2,
-    containing_service=None,
-    input_type=_SEARCHVARIANTSREQUEST,
-    output_type=_SEARCHVARIANTSRESPONSE,
-    options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002\037\"\032/v0.6.0a10/variants/search:\001*')),
-  ),
-  _descriptor.MethodDescriptor(
-    name='GetVariant',
-    full_name='ga4gh.VariantService.GetVariant',
-    index=3,
-    containing_service=None,
-    input_type=_GETVARIANTREQUEST,
-    output_type=ga4gh_dot_schemas_dot_ga4gh_dot_variants__pb2._VARIANT,
-    options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002\"\" /v0.6.0a10/variants/{variant_id}')),
-  ),
-  _descriptor.MethodDescriptor(
-    name='SearchCallSets',
-    full_name='ga4gh.VariantService.SearchCallSets',
-    index=4,
-    containing_service=None,
-    input_type=_SEARCHCALLSETSREQUEST,
-    output_type=_SEARCHCALLSETSRESPONSE,
-    options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002\037\"\032/v0.6.0a10/callsets/search:\001*')),
-  ),
-  _descriptor.MethodDescriptor(
-    name='GetCallSet',
-    full_name='ga4gh.VariantService.GetCallSet',
-    index=5,
-    containing_service=None,
-    input_type=_GETCALLSETREQUEST,
-    output_type=ga4gh_dot_schemas_dot_ga4gh_dot_variants__pb2._CALLSET,
-    options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002#\022!/v0.6.0a10/callsets/{call_set_id}')),
-  ),
-])
-_sym_db.RegisterServiceDescriptor(_VARIANTSERVICE)
-
-DESCRIPTOR.services_by_name['VariantService'] = _VARIANTSERVICE
 
 # @@protoc_insertion_point(module_scope)

--- a/src/main/proto/ga4gh/variant_service.proto
+++ b/src/main/proto/ga4gh/variant_service.proto
@@ -19,6 +19,19 @@ service VariantService {
       };
     };
 
+  // Gets a list of `Variants` matching the search criteria.
+  //
+  // `POST /variantsetsByGeneName/search` must accept a JSON version of
+  // `SearchVariantsByGeneNameRequest` as the post body and will return a JSON version
+  // of `SearchVariantsByGeneNameResponse`.
+  rpc SearchVariantsByGeneName(SearchVariantsByGeneNameRequest)
+    returns (SearchVariantsByGeneNameResponse) {
+      option (google.api.http) = {
+        post: "/v0.6.0a10/variantsbygenesearch"
+        body: "*"
+      };
+    };
+
   // Gets a `VariantSet` by ID.
   //
   // `GET /variantsets/{variant_set_id}` will return a JSON version of
@@ -39,15 +52,6 @@ service VariantService {
     returns (SearchVariantsResponse) {
       option (google.api.http) = {
         post: "/v0.6.0a10/variants/search"
-        body: "*"
-      };
-    };
-
-
-  rpc SearchVariantsByGene(SearchVariantsByGeneRequest)
-    returns (SearchVariantsResponse) {
-      option (google.api.http) = {
-        post: "/v0.6.0a10/variantsbygenesearch"
         body: "*"
       };
     };
@@ -154,28 +158,6 @@ message SearchVariantsRequest {
   string page_token = 7;
 }
 
-
-message SearchVariantsByGeneRequest {
-
-  string dataset_id = 1;
-
-  // Gene name
-  string gene = 2;
-
-  // Specifies the maximum number of results to return in a single page.
-  // If unspecified, a system default will be used.
-  int32 page_size = 3;
-
-  // The continuation token, which is used to page through large result sets. To
-  // get the next page of results, set this parameter to the value of
-  // `next_page_token` from the previous response.
-  string page_token = 4;
-
-}
-
-
-
-
 // This is the response from `POST /variants/search` expressed as JSON.
 message SearchVariantsResponse {
   // The list of matching variants.
@@ -235,4 +217,40 @@ message SearchCallSetsResponse {
 message GetCallSetRequest {
   // The ID of the `CallSet` to be retrieved.
   string call_set_id = 1;
+}
+
+
+// ******************  /variants  *********************
+// This request maps to the body of `POST /variantsnamebygenesearch` as JSON.
+message SearchVariantsByGeneNameRequest {
+  // The `VariantSet` to search.
+  string dataset_id = 1;
+
+  // The gene name to search
+  string gene = 2;
+
+  // Specifies the maximum number of results to return in a single page.
+  // If unspecified, a system default will be used.
+  int32 page_size = 3;
+
+  // The continuation token, which is used to page through large result sets.
+  // To get the next page of results, set this parameter to the value of
+  // `next_page_token` from the previous response.
+  string page_token = 4;
+}
+
+// This is the response from `POST /variantsbygenename` expressed as JSON.
+message SearchVariantsByGeneNameResponse {
+  // The list of matching variants.
+  // If the `callSetId` field on the returned calls is not present,
+  // the ordering of the call sets from a `SearchCallSetsRequest`
+  // over the parent `VariantSet` is guaranteed to match the ordering
+  // of the calls on each `Variant`. The number of results will also be
+  // the same.
+  repeated Variant variants = 1;
+
+  // The continuation token, which is used to page through large result sets.
+  // Provide this value in a subsequent request to return the next page of
+  // results. This field will be empty if there aren't any additional results.
+  string next_page_token = 2;
 }


### PR DESCRIPTION
Defined new types of response and request including SearchVariantsByGeneRequest and SearchVariantsByGeneResponse to support the generator wrapper.